### PR TITLE
Microexpansion citation

### DIFF
--- a/autolamella/milling.py
+++ b/autolamella/milling.py
@@ -140,11 +140,12 @@ def _microexpansion_coords(microscope, stage_settings, my_lamella):
 
     References
     ----------
-       
-    .. [1] Wolff G, Limpens RWAL, Zheng S, Snijder EJ, Agard DA, Koster AJ, Bárcena M.
-       "Mind the gap: Micro-expansion joints drastically decrease the bending of 
-       FIB-milled cryo-lamellae." J Struct Biol. 2019 Dec 1;208(3):107389.
-       doi: 10.1016/j.jsb.2019.09.006. Epub 2019 Sep 16. PMID: 31536774.
+
+    .. [1] Wolff G, Limpens RWAL, Zheng S, Snijder EJ, Agard DA, Koster AJ,
+       Bárcena M. "Mind the gap: Micro-expansion joints drastically decrease
+       the bending of FIB-milled cryo-lamellae." J Struct Biol.
+       2019 Dec 1;208(3):107389. doi: 10.1016/j.jsb.2019.09.006.
+       Epub 2019 Sep 16. PMID: 31536774.
        https://doi.org/10.1016/j.jsb.2019.09.006
     """
     if not ("microexpansion_width" in stage_settings

--- a/autolamella/milling.py
+++ b/autolamella/milling.py
@@ -136,8 +136,17 @@ def _milling_coords(microscope, stage_settings, my_lamella, pattern):
 
 
 def _microexpansion_coords(microscope, stage_settings, my_lamella):
-    """Mill microexpansion joints (TODO: add reference)"""
+    """Mill microexpansion joints.
 
+    References
+    ----------
+       
+    .. [1] Wolff G, Limpens RWAL, Zheng S, Snijder EJ, Agard DA, Koster AJ, Bárcena M.
+       "Mind the gap: Micro-expansion joints drastically decrease the bending of 
+       FIB-milled cryo-lamellae." J Struct Biol. 2019 Dec 1;208(3):107389.
+       doi: 10.1016/j.jsb.2019.09.006. Epub 2019 Sep 16. PMID: 31536774.
+       https://doi.org/10.1016/j.jsb.2019.09.006
+    """
     if not ("microexpansion_width" in stage_settings
             and "microexpansion_distance_from_lamella" in stage_settings
             and "microexpansion_percentage_height" in stage_settings):


### PR DESCRIPTION
Copy of PR https://github.com/DeMarcoLab/autolamella/pull/41

> I found this #TODO comment in the code, so I've added the citation information for the Wolff 2019 J Struc Biol paper on microexpansion joints: https://doi.org/10.1016/j.jsb.2019.09.006