### PR TITLE
Bugfix for rectangle/cleaning cross section application files 

### DIFF
--- a/autolamella/fiducial.py
+++ b/autolamella/fiducial.py
@@ -90,10 +90,12 @@ def fiducial(
     coord = select_fiducial_point(image, fiducial_fov_x, fiducial_fov_y)
     if coord == []:  # user did not select a fiducial location
         return
+    microscope.patterning.set_default_application_file(stage_settings['application_file_rectangle'])
     rectangle_1 = microscope.patterning.create_rectangle(
         coord[0], coord[1], fiducial_width, fiducial_length, fiducial_milling_depth
     )
     rectangle_1.rotation = np.deg2rad(45)
+    microscope.patterning.set_default_application_file(stage_settings['application_file_rectangle'])
     rectangle_2 = microscope.patterning.create_rectangle(
         coord[0], coord[1], fiducial_length, fiducial_width, fiducial_milling_depth
     )

--- a/autolamella/milling.py
+++ b/autolamella/milling.py
@@ -112,22 +112,19 @@ def _milling_coords(microscope, stage_settings, my_lamella, pattern):
         if pattern == "upper" \
         else lamella_center_y - center_offset
 
-    if stage_settings["use_cleaning_cross_section"]:
-        milling_roi = microscope.patterning.create_cleaning_cross_section(
-            lamella_center_x,
-            center_y,
-            stage_settings.get(f'lamella_width_{pattern}', stage_settings["lamella_width"]),
-            height,
-            milling_depth,
-        )
-    else:
-        milling_roi = microscope.patterning.create_rectangle(
-            lamella_center_x,
-            center_y,
-            stage_settings.get(f'lamella_width_{pattern}', stage_settings["lamella_width"]),
-            height,
-            milling_depth,
-        )
+    if stage_settings.get('patterning_shape') == "Rectangle":
+        microscope.patterning.set_default_application_file(stage_settings['application_file_rectangle'])
+    elif stage_settings.get("patterning_shape") == "CleaningCrossSection":
+        microscope.patterning.set_default_application_file(stage_settings['application_file_cleaning_cross_section'])
+        create_pattern_function = microscope.patterning.create_cleaning_cross_section
+
+    milling_roi = create_pattern_function(
+        lamella_center_x,
+        center_y,
+        stage_settings["lamella_width"],
+        height,
+        milling_depth,
+    )
     if pattern == "upper":
         milling_roi.scan_direction = "TopToBottom"
     elif pattern == "lower":
@@ -161,6 +158,7 @@ def _microexpansion_coords(microscope, stage_settings, my_lamella):
                + stage_settings["microexpansion_distance_from_lamella"]
     milling_rois = []
     for scan_direction, offset_x in (("LeftToRight", -offset_x), ("RightToLeft", offset_x)):
+        microscope.patterning.set_default_application_file(stage_settings['application_file_rectangle'])
         milling_roi = microscope.patterning.create_rectangle(
             lamella_center_x + offset_x,
             lamella_center_y,
@@ -175,9 +173,7 @@ def _microexpansion_coords(microscope, stage_settings, my_lamella):
 
 def setup_milling(microscope, settings, stage_settings, my_lamella):
     """Setup the ion beam system ready for milling."""
-    system_settings = settings["system"]
-    ccs_file = system_settings["application_file_cleaning_cross_section"]
-    microscope = reset_state(microscope, settings, application_file=ccs_file)
+    microscope = reset_state(microscope, settings)
     my_lamella.fibsem_position.restore_state(microscope)
     microscope.beams.ion_beam.beam_current.value = stage_settings["milling_current"]
     return microscope

--- a/autolamella/user_input.py
+++ b/autolamella/user_input.py
@@ -96,7 +96,9 @@ def protocol_stage_settings(settings):
     """
     protocol_stages = []
     for stage_settings in settings["lamella"]["protocol_stages"]:
-        tmp_settings = settings["lamella"].copy()
+        tmp_settings = {}
+        tmp_settings.update(settings['system'].copy())
+        tmp_settings.update(settings["lamella"].copy())
         tmp_settings.update(stage_settings)
         protocol_stages.append(tmp_settings)
     return protocol_stages

--- a/protocol_chlanda.yml
+++ b/protocol_chlanda.yml
@@ -23,8 +23,8 @@ lamella: # Lamella parameters
   total_cut_height: 5.5e-6    # In meters. Combined milling region above & below.
   milling_depth: 0.8e-6 # In meters. Default milling depth.
   milling_current: 1000e-12    # In Amperes. Default milling current.
-  patterning_mode: 'Parallel'
-  use_cleaning_cross_section: False
+  patterning_shape: 'Rectangle'  # Options are "CleaningCrossSection" or "Rectangle"
+  patterning_mode: 'Parallel'  # Options are "Serial" or "Parallel"
   # Protocol stages are milled in the order they appear here.
   # Stages may override the default parmeters above Eg: current, depth, etc.
   protocol_stages:

--- a/protocol_example.yml
+++ b/protocol_example.yml
@@ -23,8 +23,8 @@ lamella: # Lamella parameters
   total_cut_height: 5e-7 # In meters. Combined milling region above & below.
   milling_depth: 1e-6 # In meters. Default milling depth.
   milling_current: 1e-8 # In Amperes. Default milling current.
-  patterning_mode: 'Serial'
-  use_cleaning_cross_section: True # use a cleaning cross section (true) or rectangle (false) pattern 
+  patterning_shape: 'CleaningCrossSection'  # Options are "CleaningCrossSection" or "Rectangle"
+  patterning_mode: 'Serial'  # Options are "Serial" or "Parallel"
   # Protocol stages are milled in the order they appear here.
   # Stages may override the default parmeters above Eg: current, depth, etc.
   protocol_stages:


### PR DESCRIPTION
Copy of PR https://github.com/DeMarcoLab/autolamella/pull/42

> With the addition of the new microexpansion joints feature, we now need to set the default application patterning file immediately before each new pattern is created.
>
> That way the rectangle patterning file is enabled for rectangle patterns, and the cleaning cross section pattern enabled for the cleaning cross sections. This is especially important now there is a mix of pattern types in during the milling stages, due to the microexpansion joints.
